### PR TITLE
Use name mangling to prevent collisions

### DIFF
--- a/ormcache/managers.py
+++ b/ormcache/managers.py
@@ -7,12 +7,12 @@ from ormcache.queryset import CachedQuerySet
 class CachedManagerMixin(object):
 
     @cached_property
-    def _cache_enabled(self):
+    def __cache_enabled(self):
         return getattr(self.model, "cache_enabled", False)
 
-    def _require_cache(func):
+    def __require_cache(func):
         def wrapper(self, *args, **kwargs):
-            if not self._cache_enabled:
+            if not self.__cache_enabled:
                 error = "Caching is not enabled on {}".format(str(type(self)))
                 raise RuntimeError(error)
             return func(self, *args, **kwargs)
@@ -20,15 +20,15 @@ class CachedManagerMixin(object):
 
     def from_ids(self, ids, lookup='pk__in', **kwargs):
         queryset = self.get_query_set()
-        if not self._cache_enabled:
+        if not self.__cache_enabled:
             return queryset.filter(**{lookup: ids})
         return queryset.from_ids(ids, lookup=lookup, **kwargs)
 
-    @_require_cache
+    @__require_cache
     def invalidate(self, *args, **kwargs):
         return self.get_query_set().invalidate(*args, **kwargs)
 
-    @_require_cache
+    @__require_cache
     def cache_key(self, *args, **kwargs):
         return self.get_query_set().cache_key(*args, **kwargs)
 
@@ -39,28 +39,28 @@ class CachedManagerMixin(object):
         Overrides Django builtin
         """
         super(CachedManagerMixin, self).contribute_to_class(model, name)
-        class_prepared.connect(self._class_prepared_cache, sender=model)
+        class_prepared.connect(self.__class_prepared_cache, sender=model)
 
     def get_query_set(self):
         """
         Overrides Django builtin
         """
-        if self._cache_enabled:
+        if self.__cache_enabled:
             return CachedQuerySet(self.model)
         else:
             return super(CachedManagerMixin, self).get_query_set()
 
     # Signals
 
-    def _class_prepared_cache(self, sender, **kwargs):
-        if self._cache_enabled:
-            post_save.connect(self._post_save_cache,
+    def __class_prepared_cache(self, sender, **kwargs):
+        if self.__cache_enabled:
+            post_save.connect(self.__post_save_cache,
                               sender=self.model, weak=False)
-            post_delete.connect(self._post_delete_cache,
+            post_delete.connect(self.__post_delete_cache,
                                 sender=self.model, weak=False)
 
-    def _post_save_cache(self, instance, created, **kwargs):
+    def __post_save_cache(self, instance, created, **kwargs):
         self.invalidate(instance.pk, recache=True)
 
-    def _post_delete_cache(self, instance, **kwargs):
+    def __post_delete_cache(self, instance, **kwargs):
         self.invalidate(instance.pk)

--- a/ormcache/queryset.py
+++ b/ormcache/queryset.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class CachedQuerySet(QuerySet):
 
-    _CACHE_FOREVER = 2592000  # http://ur1.ca/egyvu
+    __CACHE_FOREVER = 2592000  # http://ur1.ca/egyvu
 
     def get(self, *args, **kwargs):
         """
@@ -47,7 +47,7 @@ class CachedQuerySet(QuerySet):
         if item is None:
             cache_missed.send(sender=self.model)
             item = super(CachedQuerySet, self).get(*args, **kwargs)
-            cache.set(key, item, self._CACHE_FOREVER)
+            cache.set(key, item, self.__CACHE_FOREVER)
         else:
             cache_hit.send(sender=self.model)
 
@@ -70,7 +70,7 @@ class CachedQuerySet(QuerySet):
 
             # Cache the uncached instances
             to_cache = {self.cache_key(i.pk): i for i in uncached}
-            cache.set_many(to_cache, self._CACHE_FOREVER)
+            cache.set_many(to_cache, self.__CACHE_FOREVER)
 
         return cached_instances
 
@@ -96,6 +96,6 @@ class CachedQuerySet(QuerySet):
                     exc_info=True,
                     extra={'data': {'model': self.model, 'pk': pk}})
             else:
-                cache.set(key, entry, self._CACHE_FOREVER)
+                cache.set(key, entry, self.__CACHE_FOREVER)
         else:
             cache.delete(key)


### PR DESCRIPTION
"Private" methods should be prefixed by `__` to prevent collisions. [More info here](https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references)
