### PR TITLE
Limited handling of filtered querysets

### DIFF
--- a/ormcache/queryset.py
+++ b/ormcache/queryset.py
@@ -24,27 +24,30 @@ class CachedQuerySet(QuerySet):
         'get()' method will be cached indefinitely (30 days) until invalidated.
         """
 
+        orig_kwargs = kwargs.copy()
+
         # If this queryset is filtered by a single column and no arguments
         # were passed to get(), treat the queryset filter as an argument to
         # get(). This lets Model.objects.filter(pk=42).get() work like
         # Model.objects.get(pk=42).
+        can_ignore_filter = False
         if (len(self.query.where) == 1
                 and not kwargs
                 and django.VERSION >= (1, 7)
                 and not self.query.where.negated):
             child, = self.query.where.children
             if isinstance(child, Exact) and isinstance(child.lhs, Col):
-                self.query.where.children.pop()
+                can_ignore_filter = True
                 kwargs[child.lhs.target.attname] = child.rhs
 
         # Don't access cache if using a filtered queryset
-        if self.query.where:
-            return super(CachedQuerySet, self).get(*args, **kwargs)
+        if self.query.where and not can_ignore_filter:
+            return super(CachedQuerySet, self).get(*args, **orig_kwargs)
 
         # Don't access cache if using a deferred queryset
         if len(self.query.deferred_loading[0]) > 0 or \
                 not self.query.deferred_loading[1]:
-            return super(CachedQuerySet, self).get(*args, **kwargs)
+            return super(CachedQuerySet, self).get(*args, **orig_kwargs)
 
         # Get the cache key from the model name and pk
         if "pk" in kwargs:
@@ -56,7 +59,7 @@ class CachedQuerySet(QuerySet):
         elif "id__exact" in kwargs:
             pk = kwargs["id__exact"]
         else:
-            return super(CachedQuerySet, self).get(*args, **kwargs)
+            return super(CachedQuerySet, self).get(*args, **orig_kwargs)
 
         key = self.cache_key(pk)
 
@@ -64,7 +67,7 @@ class CachedQuerySet(QuerySet):
         item = cache.get(key)
         if item is None:
             cache_missed.send(sender=self.model)
-            item = super(CachedQuerySet, self).get(*args, **kwargs)
+            item = super(CachedQuerySet, self).get(*args, **orig_kwargs)
             cache.set(key, item, self.__CACHE_FOREVER)
         else:
             cache_hit.send(sender=self.model)

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -1,3 +1,4 @@
+import django
 from django.core.cache import cache
 from django.test import TestCase
 
@@ -25,6 +26,11 @@ class CachedQuerySetTestCase(TestCase):
         # Use .get() after .filter(...), should not set cache
         CachedDummyModel.objects.filter(pk__gt=0).get(pk=self.instance1.pk)
         self.assertIsNone(cache.get(cache_key))
+
+        # Use .get() after .filter(pk=), should set cache
+        if django.VERSION >= (1, 7):
+            CachedDummyModel.objects.filter(pk=self.instance1.pk).get()
+            self.assertIsNotNone(cache.get(cache_key))
 
         # Use .get() normally, should set cache
         CachedDummyModel.objects.get(pk=self.instance1.pk)

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -19,21 +19,30 @@ class CachedQuerySetTestCase(TestCase):
         self.assertIsNone(cache.get(cache_key))
 
         # Use .get() after .filter() with no args, should set cache
-        CachedDummyModel.objects.filter().get(pk=self.instance1.pk)
+        with self.assertNumQueries(1):
+            CachedDummyModel.objects.filter().get(pk=self.instance1.pk)
+            CachedDummyModel.objects.filter().get(pk=self.instance1.pk)
         self.assertIsNotNone(cache.get(cache_key))
         cache.clear()
 
         # Use .get() after .filter(...), should not set cache
-        CachedDummyModel.objects.filter(pk__gt=0).get(pk=self.instance1.pk)
+        with self.assertNumQueries(2):
+            CachedDummyModel.objects.filter(pk__gt=0).get(pk=self.instance1.pk)
+            CachedDummyModel.objects.filter(pk__gt=0).get(pk=self.instance1.pk)
         self.assertIsNone(cache.get(cache_key))
 
         # Use .get() after .filter(pk=), should set cache
         if django.VERSION >= (1, 7):
-            CachedDummyModel.objects.filter(pk=self.instance1.pk).get()
+            with self.assertNumQueries(1):
+                CachedDummyModel.objects.filter(pk=self.instance1.pk).get()
+                CachedDummyModel.objects.filter(pk=self.instance1.pk).get()
             self.assertIsNotNone(cache.get(cache_key))
+            cache.clear()
 
         # Use .get() normally, should set cache
-        CachedDummyModel.objects.get(pk=self.instance1.pk)
+        with self.assertNumQueries(1):
+            CachedDummyModel.objects.get(pk=self.instance1.pk)
+            CachedDummyModel.objects.get(pk=self.instance1.pk)
         self.assertIsNotNone(cache.get(cache_key))
 
     def test_from_ids_cache(self):


### PR DESCRIPTION
This treats `Model.objects.filter(pk=42).get()` the same as `Model.objects.get(pk=42)`.

I limited this to Django 1.7+ because of the large `WhereNode` refactoring done in https://github.com/django/django/commit/20bab2cf9d02a5c6477d8aac066a635986e0d3f3

Fixes #30