### PR TITLE
Do not log an error when invalidate on delete

### DIFF
--- a/ormcache/queryset.py
+++ b/ormcache/queryset.py
@@ -111,8 +111,12 @@ class CachedQuerySet(QuerySet):
         if recache is True:
             try:
                 entry = super(CachedQuerySet, self).get(pk=pk)
-            except (self.model.DoesNotExist,
-                    self.model.MultipleObjectsReturned):
+            except self.model.DoesNotExist:
+                log.info(
+                    'Unable to recache model during invalidate',
+                    exc_info=True,
+                    extra={'data': {'model': self.model, 'pk': pk}})
+            except self.model.MultipleObjectsReturned:
                 log.error(
                     'Error retrieving single entry from database',
                     exc_info=True,


### PR DESCRIPTION
After deleting an object, getting a DoesNotExist exception is not an
error, so do not log it as such